### PR TITLE
Get the api token from an env var

### DIFF
--- a/hubtraf/check.py
+++ b/hubtraf/check.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import structlog
 import argparse
 import random
@@ -14,10 +15,11 @@ import secrets
 async def no_auth(*args, **kwargs):
     return True
 
-async def check_user(hub_url, username):
+async def check_user(hub_url, username, api_token_env_var):
+    api_token = os.environ[api_token_env_var]
     async with User(username, hub_url, no_auth) as u:
         try:
-            if not await u.ensure_server_api():
+            if not await u.ensure_server_api(api_token):
                 return 'start-server'
             if not await u.start_kernel():
                 return 'start-kernel'
@@ -44,10 +46,15 @@ def main():
         'username',
         help='Name of user to check'
     )
+    argparser.add_argument(
+        'api_token_env_var',
+        help='Name of env var storing the Hub api token'
+    )
     args = argparser.parse_args()
 
+
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(check_user(args.hub_url, args.username))
+    loop.run_until_complete(check_user(args.hub_url, args.username, args.api_token_env_var))
 
 
 if __name__ == '__main__':

--- a/hubtraf/check.py
+++ b/hubtraf/check.py
@@ -15,8 +15,7 @@ import secrets
 async def no_auth(*args, **kwargs):
     return True
 
-async def check_user(hub_url, username, api_token_env_var):
-    api_token = os.environ[api_token_env_var]
+async def check_user(hub_url, username, api_token):
     async with User(username, hub_url, no_auth) as u:
         try:
             if not await u.ensure_server_api(api_token):
@@ -46,15 +45,12 @@ def main():
         'username',
         help='Name of user to check'
     )
-    argparser.add_argument(
-        'api_token_env_var',
-        help='Name of env var storing the Hub api token'
-    )
     args = argparser.parse_args()
 
+    api_token = os.environ['JUPYTERHUB_API_TOKEN']
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(check_user(args.hub_url, args.username, args.api_token_env_var))
+    loop.run_until_complete(check_user(args.hub_url, args.username, api_token))
 
 
 if __name__ == '__main__':

--- a/hubtraf/user.py
+++ b/hubtraf/user.py
@@ -93,9 +93,9 @@ class User:
         self.state = User.States.LOGGED_IN
         return True
 
-    async def ensure_server_api(self, timeout=300, spawn_refresh_time=30):
+    async def ensure_server_api(self, api_token, timeout=300, spawn_refresh_time=30):
         api_url = self.hub_url / 'hub/api'
-        self.headers['Authorization'] = 'token 16c7709a19b04f77a11bc6f4b88a9080'
+        self.headers['Authorization'] = f'token {api_token}'
 
         async def server_running():
             async with self.session.get(api_url / 'users' / self.username, headers=self.headers) as resp:


### PR DESCRIPTION
This allows passing to `hubtraf-check` the name of the env var holding the Hub api token.
We could also assume its name (eg `JUPYTERHUB_API_TOKEN`) and read it directly.

@yuvipanda, WDYT? Does this need to be customizable?