### PR TITLE
trailing slash in notebook_url

### DIFF
--- a/hubtraf/user.py
+++ b/hubtraf/user.py
@@ -49,7 +49,7 @@ class User:
         self.hub_url = URL(hub_url)
 
         self.state = User.States.CLEAR
-        self.notebook_url = self.hub_url / 'user' / self.username
+        self.notebook_url = self.hub_url / 'user' / self.username / ''
 
         self.log = logger.bind(
             username=username


### PR DESCRIPTION
otherwise xsrf cookie filter will exclude cookies set on the server path prefix

needed for https://github.com/jupyterhub/the-littlest-jupyterhub/pull/842