### PR TITLE
ci: test against jupyterhub 5 and python 3.13, stop testing jupyterhub 2 and python 3.8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,21 +24,23 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.8"
-            pip-install-spec: "jupyterhub==2.* sqlalchemy==1.*"
           - python-version: "3.9"
             pip-install-spec: "jupyterhub==3.*"
           - python-version: "3.11"
             pip-install-spec: "jupyterhub==4.*"
           - python-version: "3.12"
             pip-install-spec: "jupyterhub==4.*"
+          - python-version: "3.13"
+            pip-install-spec: "jupyterhub==5.*"
+          - python-version: "3.x"
+            pip-install-spec: "--pre jupyterhub"
 
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +49,7 @@ jobs:
           python-version: "${{ matrix.python-version }}"
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "lts/*"
 
       - name: Install Node dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ target_version = [
     "py310",
     "py311",
     "py312",
+    "py313",
 ]
 
 # isort is used for autoformatting Python code


### PR DESCRIPTION
I'm seeing test failures in tljh for jupyterhub 5.2.0, but not for 5.1.0, for when hubtraf User object's method `ensure_server_simulate` is called.

From [this test run on GitHub Actions](https://github.com/jupyterhub/the-littlest-jupyterhub/actions/runs/11424843572/job/31785713578?pr=1008)

```
    async def test_user_code_execute():
        """
        User logs in, starts a server & executes code
        """
        username = secrets.token_hex(8)
    
        assert (
            0
            == await (
                await asyncio.create_subprocess_exec(
                    *TLJH_CONFIG_PATH, "set", "auth.type", "dummy"
                )
            ).wait()
        )
        assert (
            0
            == await (
                await asyncio.create_subprocess_exec(*TLJH_CONFIG_PATH, "reload")
            ).wait()
        )
    
        async with User(username, HUB_URL, partial(login_dummy, password="")) as u:
            assert await u.login()
>           assert await u.ensure_server_simulate(timeout=60, spawn_refresh_time=5)
E           assert False
```