### PR TITLE
Typo/license link fixes for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## License
 
-See [LICENCE](LICENCE).
+See [LICENSE](LICENSE).
 
-## Geting started with the Python module
+## Getting started with the Python module
 
 Install the latest version with
 


### PR DESCRIPTION
Fixes `LICENSE` link and a typo. This repo was helpful for some testing recently. Thanks!